### PR TITLE
Validate migration files checksum on Start

### DIFF
--- a/plugin/src/main/scala/org/flywaydb/play/ConfigReader.scala
+++ b/plugin/src/main/scala/org/flywaydb/play/ConfigReader.scala
@@ -44,6 +44,7 @@ class ConfigReader(configuration: Configuration, environment: Environment) {
       val encoding = subConfig.getString("encoding").getOrElse("UTF-8")
       val placeholderPrefix = subConfig.getString("placeholderPrefix")
       val placeholderSuffix = subConfig.getString("placeholderSuffix")
+      val validateOnStart = subConfig.getBoolean("validateOnStart").getOrElse(false)
 
       val placeholders = {
         subConfig.getConfig("placeholders").map { config =>
@@ -65,6 +66,7 @@ class ConfigReader(configuration: Configuration, environment: Environment) {
 
       dbName -> FlywayConfiguration(
         database,
+        validateOnStart,
         auto,
         initOnMigrate,
         validateOnMigrate,

--- a/plugin/src/main/scala/org/flywaydb/play/FlywayConfiguration.scala
+++ b/plugin/src/main/scala/org/flywaydb/play/FlywayConfiguration.scala
@@ -17,6 +17,7 @@ package org.flywaydb.play
 
 case class FlywayConfiguration(
   database: DatabaseConfiguration,
+  validateOnStart: Boolean,
   auto: Boolean,
   initOnMigrate: Boolean,
   validateOnMigrate: Boolean,

--- a/plugin/src/main/scala/org/flywaydb/play/PlayInitializer.scala
+++ b/plugin/src/main/scala/org/flywaydb/play/PlayInitializer.scala
@@ -121,6 +121,10 @@ class PlayInitializer @Inject() (
           dbName,
           pendingMigrations.map(migration => migrationDescriptionToShow(dbName, migration)).mkString("\n"))
       }
+
+      if (flywayConfigurations(dbName).validateOnStart) {
+        flyway.validate()
+      }
     }
   }
 


### PR DESCRIPTION
Checks migration files checksum on start, making the app fail if the expected migration SQL files are not the some as the applied migration files. This helps to catch up unexpected errors and mismatch.

Error:
```
org.flywaydb.core.api.FlywayException
: Validate failed: Migration checksum mismatch for migration
```